### PR TITLE
fix: wrong IncreaseAdditionalValidatorStake bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ func main() {
   }
   //---------------
 
-  recent, err := rpcClient.GetRecentBlockhash(context.TODO(), rpc.CommitmentFinalized)
+  recent, err := rpcClient.GetLatestBlockhash(context.TODO(), rpc.CommitmentFinalized)
   if err != nil {
     panic(err)
   }
@@ -1072,7 +1072,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(context.TODO(), rpc.CommitmentFinalized)
+  example, err := client.GetLatestBlockhash(context.TODO(), rpc.CommitmentFinalized)
   if err != nil {
     panic(err)
   }
@@ -1125,7 +1125,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(context.TODO(), rpc.CommitmentFinalized)
+  example, err := client.GetLatestBlockhash(context.TODO(), rpc.CommitmentFinalized)
   if err != nil {
     panic(err)
   }
@@ -1227,7 +1227,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -1263,7 +1263,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -1301,7 +1301,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -1367,7 +1367,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -1424,7 +1424,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -1465,7 +1465,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -1631,7 +1631,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  example, err := client.GetRecentBlockhash(
+  example, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )
@@ -2212,6 +2212,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
+  // DEPRECATED: This method is only available in solana-core v1.8 or older. Please use getLatestBlockhash for solana-core v1.9 or newer.
   recent, err := client.GetRecentBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
@@ -2409,7 +2410,7 @@ func main() {
   endpoint := rpc.TestNet_RPC
   client := rpc.New(endpoint)
 
-  recent, err := client.GetRecentBlockhash(
+  recent, err := client.GetLatestBlockhash(
     context.TODO(),
     rpc.CommitmentFinalized,
   )

--- a/README.md
+++ b/README.md
@@ -2954,6 +2954,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()	
   client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
   if err != nil {
     panic(err)
@@ -2971,7 +2972,7 @@ func main() {
     defer sub.Unsubscribe()
 
     for {
-      got, err := sub.Recv()
+      got, err := sub.Recv(ctx)
       if err != nil {
         panic(err)
       }
@@ -2991,7 +2992,7 @@ func main() {
     defer sub.Unsubscribe()
 
     for {
-      got, err := sub.Recv()
+      got, err := sub.Recv(ctx)
       if err != nil {
         panic(err)
       }
@@ -3016,6 +3017,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()	
   client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
   if err != nil {
     panic(err)
@@ -3034,7 +3036,7 @@ func main() {
     defer sub.Unsubscribe()
 
     for {
-      got, err := sub.Recv()
+      got, err := sub.Recv(ctx)
       if err != nil {
         panic(err)
       }
@@ -3053,7 +3055,7 @@ func main() {
     defer sub.Unsubscribe()
 
     for {
-      got, err := sub.Recv()
+      got, err := sub.Recv(ctx)
       if err != nil {
         panic(err)
       }
@@ -3078,6 +3080,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()	
   client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
   if err != nil {
     panic(err)
@@ -3096,7 +3099,7 @@ func main() {
   defer sub.Unsubscribe()
 
   for {
-    got, err := sub.Recv()
+    got, err := sub.Recv(ctx)
     if err != nil {
       panic(err)
     }
@@ -3130,6 +3133,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()
   client, err := ws.Connect(context.Background(), rpc.TestNet_WS)
   if err != nil {
     panic(err)
@@ -3141,7 +3145,7 @@ func main() {
   }
 
   for {
-    got, err := sub.Recv()
+    got, err := sub.Recv(ctx)
     if err != nil {
       panic(err)
     }
@@ -3165,6 +3169,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()
   client, err := ws.Connect(context.Background(), rpc.TestNet_WS)
   if err != nil {
     panic(err)
@@ -3182,7 +3187,7 @@ func main() {
   defer sub.Unsubscribe()
 
   for {
-    got, err := sub.Recv()
+    got, err := sub.Recv(ctx)
     if err != nil {
       panic(err)
     }
@@ -3205,6 +3210,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()
   client, err := ws.Connect(context.Background(), rpc.TestNet_WS)
   if err != nil {
     panic(err)
@@ -3217,7 +3223,7 @@ func main() {
   defer sub.Unsubscribe()
 
   for {
-    got, err := sub.Recv()
+    got, err := sub.Recv(ctx)
     if err != nil {
       panic(err)
     }
@@ -3240,6 +3246,7 @@ import (
 )
 
 func main() {
+  ctx := context.Background()
   client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
   if err != nil {
     panic(err)
@@ -3254,7 +3261,7 @@ func main() {
   defer sub.Unsubscribe()
 
   for {
-    got, err := sub.Recv()
+    got, err := sub.Recv(ctx)
     if err != nil {
       panic(err)
     }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The RPC and WS client implementation is based on [this RPC spec](https://github.
 
 ## Requirements
 
-- Go 1.18 or later
+- Go 1.19 or later
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solana SDK library for Go
 
-[![GoDoc](https://pkg.go.dev/badge/github.com/gagliardetto/solana-go?status.svg)](https://pkg.go.dev/github.com/gagliardetto/solana-go@v1.11.0?tab=doc)
+[![GoDoc](https://pkg.go.dev/badge/github.com/gagliardetto/solana-go?status.svg)](https://pkg.go.dev/github.com/gagliardetto/solana-go@v1.12.0?tab=doc)
 [![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/gagliardetto/solana-go?include_prereleases&label=release-tag)](https://github.com/gagliardetto/solana-go/releases)
 [![Build Status](https://github.com/gagliardetto/solana-go/workflows/tests/badge.svg?branch=main)](https://github.com/gagliardetto/solana-go/actions?query=branch%3Amain)
 [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/gagliardetto/solana-go/main)](https://www.tickgit.com/browse?repo=github.com/gagliardetto/solana-go&branch=main)
@@ -83,7 +83,7 @@ Thanks!
 
 ## Current development status
 
-There is currently **no stable release**. The SDK is actively developed and latest is `v1.11.0` which is an `alpha` release.
+There is currently **no stable release**. The SDK is actively developed and latest is `v1.12.0` which is an `alpha` release.
 
 The RPC and WS client implementation is based on [this RPC spec](https://github.com/solana-labs/solana/blob/c2435363f39723cef59b91322f3b6a815008af29/docs/src/developing/clients/jsonrpc-api.md).
 
@@ -100,7 +100,7 @@ The RPC and WS client implementation is based on [this RPC spec](https://github.
 
 ```bash
 $ cd my-project
-$ go get github.com/gagliardetto/solana-go@v1.11.0
+$ go get github.com/gagliardetto/solana-go@v1.12.0
 ```
 
 ## Pretty-Print transactions/instructions

--- a/keys.go
+++ b/keys.go
@@ -718,3 +718,19 @@ func FindTokenMetadataAddress(mint PublicKey) (PublicKey, uint8, error) {
 	}
 	return FindProgramAddress(seed, TokenMetadataProgramID)
 }
+
+// Get the marketAuthority(PDA) from the Market Initialization
+func GetAssociatedAuthority(programID PublicKey, marketAddr PublicKey) (PublicKey, uint8, error) {
+	var address PublicKey
+	var err error
+	bumpSeed := uint8(0)
+	endSeed := []byte{0, 0, 0, 0, 0, 0, 0}
+	for bumpSeed < 100 {
+		address, err = CreateProgramAddress([][]byte{marketAddr[:], []byte{byte(bumpSeed)}, endSeed}, programID)
+		if err == nil {
+			return address, bumpSeed, nil
+		}
+		bumpSeed++
+	}
+	return PublicKey{}, bumpSeed, errors.New("unable to find a valid program address")
+}

--- a/program_ids.go
+++ b/program_ids.go
@@ -39,6 +39,9 @@ var (
 	FeatureProgramID = MustPublicKeyFromBase58("Feature111111111111111111111111111111111111")
 
 	ComputeBudget = MustPublicKeyFromBase58("ComputeBudget111111111111111111111111111111")
+
+	// Create and manage address lookup tables.
+	AddressLookupTableProgramID = MustPublicKeyFromBase58("AddressLookupTab1e1111111111111111111111111")
 )
 
 // SPL:

--- a/programs/serum/rpc.go
+++ b/programs/serum/rpc.go
@@ -101,14 +101,14 @@ func FetchMarket(ctx context.Context, rpcCli *rpc.Client, marketAddr solana.Publ
 	return meta, nil
 }
 
-func StreamOpenOrders(client *ws.Client) error {
+func StreamOpenOrders(ctx context.Context, client *ws.Client) error {
 	sub, err := client.ProgramSubscribe(DEXProgramIDV2, rpc.CommitmentSingleGossip)
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to programID %q: %w", DEXProgramIDV2, err)
 	}
 	count := 0
 	for {
-		d, err := sub.Recv()
+		d, err := sub.Recv(ctx)
 		if err != nil {
 			return fmt.Errorf("received error from programID subscription: %w", err)
 		}

--- a/programs/serum/rpc_test.go
+++ b/programs/serum/rpc_test.go
@@ -66,6 +66,6 @@ func TestStreamOpenOrders(t *testing.T) {
 	client, err := ws.Connect(context.Background(), rpcURL)
 	require.NoError(t, err)
 
-	err = StreamOpenOrders(client)
+	err = StreamOpenOrders(context.Background(), client)
 	require.NoError(t, err)
 }

--- a/programs/stake-pool/DecreaseValidatorStakeWithReserve.go
+++ b/programs/stake-pool/DecreaseValidatorStakeWithReserve.go
@@ -1,0 +1,301 @@
+// Copyright 2021 github.com/gagliardetto
+// Copyright 2025 github.com/liquid-collective
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stakepool
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+type DecreaseValidatorStakeWithReserve struct {
+	Lamports           *uint64
+	TransientStakeSeed *uint64
+	// [0] = [] stakePool
+	// [1] = [SIGNER] staker
+	// [2] = [] stakePoolWithdrawAuthority
+	// [3] = [WRITE] validatorList
+	// [4] = [WRITE] reserveStakeAccount
+	// [5] = [WRITE] canonicalStakeAccount
+	// [6] = [WRITE] transientStakeAccount
+	// [7] = [] sysvarClock
+	// [8] = [] sysvarStakeHistory
+	// [9] = [] systemProgram
+	// [10] = [] stakeProgram
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func NewDecreaseValidatorStakeWithReserveWithReserveInstruction(
+	// Parameters:
+	lamports uint64,
+	transientStakeSeed uint64,
+	// Accounts:
+	stakePool ag_solanago.PublicKey,
+	staker ag_solanago.PublicKey,
+	stakePoolWithdrawAuthority ag_solanago.PublicKey,
+	validatorList ag_solanago.PublicKey,
+	reserveStakeAccount ag_solanago.PublicKey,
+	canonicalStakeAccount ag_solanago.PublicKey,
+	transientStakeAccount ag_solanago.PublicKey,
+	sysvarClock ag_solanago.PublicKey,
+	sysvarStakeHistory ag_solanago.PublicKey,
+	systemProgram ag_solanago.PublicKey,
+	stakeProgram ag_solanago.PublicKey,
+) *DecreaseValidatorStakeWithReserve {
+	return NewDecreaseValidatorStakeWithReserveWithReserveInstructionBuilder().
+		SetLamports(lamports).
+		SetTransientStakeSeed(transientStakeSeed).
+		SetStakePool(stakePool).
+		SetStaker(staker).
+		SetStakePoolWithdrawAuthority(stakePoolWithdrawAuthority).
+		SetValidatorList(validatorList).
+		SetReserveStakeAccount(reserveStakeAccount).
+		SetCanonicalStakeAccount(canonicalStakeAccount).
+		SetTransientStakeAccount(transientStakeAccount).
+		SetSysvarClock(sysvarClock).
+		SetSysvarStakeHistory(sysvarStakeHistory).
+		SetSystemProgram(systemProgram).
+		SetStakeProgram(stakeProgram)
+}
+
+func NewDecreaseValidatorStakeWithReserveWithReserveInstructionBuilder() *DecreaseValidatorStakeWithReserve {
+	return &DecreaseValidatorStakeWithReserve{
+		Accounts: make(ag_solanago.AccountMetaSlice, 11),
+		Signers:  make(ag_solanago.AccountMetaSlice, 1),
+	}
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetLamports(lamports uint64) *DecreaseValidatorStakeWithReserve {
+	inst.Lamports = &lamports
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetTransientStakeSeed(transientStakeSeed uint64) *DecreaseValidatorStakeWithReserve {
+	inst.TransientStakeSeed = &transientStakeSeed
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetStakePool(pool ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[0] = ag_solanago.Meta(pool)
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetStaker(staker ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[1] = ag_solanago.Meta(staker).SIGNER()
+	inst.Signers[0] = ag_solanago.Meta(staker).SIGNER()
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetStakePoolWithdrawAuthority(stakePoolWithdrawAuthority ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[2] = ag_solanago.Meta(stakePoolWithdrawAuthority)
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetValidatorList(validatorList ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[3] = ag_solanago.Meta(validatorList).WRITE()
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetReserveStakeAccount(reserveStakeAccount ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[4] = ag_solanago.Meta(reserveStakeAccount).WRITE()
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetCanonicalStakeAccount(canonicalStakeAccount ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[5] = ag_solanago.Meta(canonicalStakeAccount).WRITE()
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetTransientStakeAccount(transientStakeAccount ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[6] = ag_solanago.Meta(transientStakeAccount).WRITE()
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetSysvarClock(sysvarClock ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[7] = ag_solanago.Meta(sysvarClock)
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetSysvarStakeHistory(sysvarStakeHist ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[8] = ag_solanago.Meta(sysvarStakeHist)
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetSystemProgram(systemProgram ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[9] = ag_solanago.Meta(systemProgram)
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) SetStakeProgram(stakeProgram ag_solanago.PublicKey) *DecreaseValidatorStakeWithReserve {
+	inst.Accounts[10] = ag_solanago.Meta(stakeProgram)
+	return inst
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetLamports() *uint64 {
+	return inst.Lamports
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetTransientStakeSeed() *uint64 {
+	return inst.TransientStakeSeed
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetStakePool() ag_solanago.PublicKey {
+	return inst.Accounts[0].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetStaker() ag_solanago.PublicKey {
+	return inst.Accounts[1].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetStakePoolWithdrawAuthority() ag_solanago.PublicKey {
+	return inst.Accounts[2].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetValidatorList() ag_solanago.PublicKey {
+	return inst.Accounts[3].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetReserveStakeAccount() ag_solanago.PublicKey {
+	return inst.Accounts[4].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetCanonicalStakeAccount() ag_solanago.PublicKey {
+	return inst.Accounts[5].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetTransientStakeAccount() ag_solanago.PublicKey {
+	return inst.Accounts[6].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetSysvarClock() ag_solanago.PublicKey {
+	return inst.Accounts[7].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetSysvarStakeHistory() ag_solanago.PublicKey {
+	return inst.Accounts[8].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetSystemProgram() ag_solanago.PublicKey {
+	return inst.Accounts[9].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) GetStakeProgram() ag_solanago.PublicKey {
+	return inst.Accounts[10].PublicKey
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) Build() *Instruction {
+	return &Instruction{
+		BaseVariant: ag_binary.BaseVariant{
+			TypeID: ag_binary.TypeIDFromUint8(Instruction_DecreaseValidatorStakeWithReserve),
+			Impl:   inst,
+		},
+	}
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("DecreaseValidatorStakeWithReserve")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						if inst.Lamports != nil {
+							paramsBranch.Child(ag_format.Param("Lamports", *inst.Lamports))
+						}
+						if inst.TransientStakeSeed != nil {
+							paramsBranch.Child(ag_format.Param("TransientStakeSeed", *inst.TransientStakeSeed))
+						}
+					})
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						for i, account := range inst.Accounts {
+							accountsBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", i), account))
+						}
+						signersBranch := accountsBranch.Child(fmt.Sprintf("signers[len=%v]", len(inst.Signers)))
+						for j, signer := range inst.Signers {
+							signersBranch.Child(ag_format.Meta(fmt.Sprintf("[%v]", j), signer))
+						}
+					})
+				})
+		})
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
+	if inst.Lamports != nil {
+		if err := encoder.Encode(inst.Lamports); err != nil {
+			return err
+		}
+	}
+	if inst.TransientStakeSeed != nil {
+		if err := encoder.Encode(inst.TransientStakeSeed); err != nil {
+			return err
+		}
+	}
+	for _, account := range inst.Accounts {
+		if err := encoder.Encode(account); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
+	if inst.Lamports != nil {
+		if err := decoder.Decode(inst.Lamports); err != nil {
+			return err
+		}
+	}
+	if inst.TransientStakeSeed != nil {
+		if err := decoder.Decode(inst.TransientStakeSeed); err != nil {
+			return err
+		}
+	}
+	for i := range inst.Accounts {
+		if err := decoder.Decode(inst.Accounts[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (inst *DecreaseValidatorStakeWithReserve) Validate() error {
+	if inst.Lamports == nil {
+		return errors.New("lamports is not set")
+	}
+	if inst.TransientStakeSeed == nil {
+		return errors.New("transientStakeSeed is not set")
+	}
+	for i, account := range inst.Accounts {
+		if account == nil {
+			return fmt.Errorf("accounts[%v] is not set", i)
+		}
+	}
+	if len(inst.Signers) == 0 || !inst.Signers[0].IsSigner {
+		return errors.New("accounts.Staker should be a signer")
+	}
+	return nil
+}

--- a/programs/stake-pool/instructions.go
+++ b/programs/stake-pool/instructions.go
@@ -57,14 +57,15 @@ const (
 	Instruction_SetManager
 	Instruction_SetFee
 	Instruction_SetStaker
-	Instruction_DecreaseAdditionalValidatorStake
-	Instruction_IncreaseAdditionalValidatorStake
-	Instruction_Redelegate
-	Instruction_SetFundingAuthority
 	Instruction_DepositSol
+	Instruction_SetFundingAuthority
 	Instruction_WithdrawSol
 	Instruction_CreateTokenMetadata
 	Instruction_UpdateTokenMetadata
+	Instruction_IncreaseAdditionalValidatorStake
+	Instruction_DecreaseAdditionalValidatorStake
+	Instruction_DecreaseValidatorStakeWithReserve
+	Instruction_Redelegate
 	Instruction_DepositStakeWithSlippage
 	Instruction_WithdrawStakeWithSlippage
 	Instruction_DepositSolWithSlippage

--- a/programs/token/AmountToUiAmount.go
+++ b/programs/token/AmountToUiAmount.go
@@ -1,0 +1,156 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// Convert an Amount of tokens to a `UiAmount` string, using the given mint.
+type AmountToUiAmount struct {
+	// The amount of tokens to convert.
+	Amount *uint64
+
+	// [0] = [] mint
+	// ··········· The mint.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *AmountToUiAmount) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+func (inst AmountToUiAmount) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	return
+}
+
+func NewAmountToUiAmountInstructionBuilder() *AmountToUiAmount {
+	nd := &AmountToUiAmount{
+		Accounts: make(ag_solanago.AccountMetaSlice, 1),
+	}
+	return nd
+}
+
+// SetAmount sets the "amount" parameter.
+// The amount of tokens to convert.
+func (inst *AmountToUiAmount) SetAmount(amount uint64) *AmountToUiAmount {
+	inst.Amount = &amount
+	return inst
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint.
+func (inst *AmountToUiAmount) SetMintAccount(mint ag_solanago.PublicKey) *AmountToUiAmount {
+	inst.Accounts[0] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint.
+func (inst *AmountToUiAmount) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+func (inst AmountToUiAmount) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_AmountToUiAmount),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst AmountToUiAmount) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *AmountToUiAmount) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.Amount == nil {
+			return errors.New("Amount parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *AmountToUiAmount) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("AmountToUiAmount")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("Amount", *inst.Amount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("mint", inst.Accounts[0]))
+					})
+				})
+		})
+}
+
+func (inst AmountToUiAmount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `Amount` param:
+	err = encoder.Encode(inst.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (inst *AmountToUiAmount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `Amount`:
+	err = decoder.Decode(&inst.Amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewAmountToUiAmountInstruction declares a new AmountToUiAmount instruction with the provided parameters and accounts.
+func NewAmountToUiAmountInstruction(
+	// Parameters:
+	amount uint64,
+	// Accounts:
+	mint ag_solanago.PublicKey,
+) *AmountToUiAmount {
+	return NewAmountToUiAmountInstructionBuilder().
+		SetAmount(amount).
+		SetMintAccount(mint)
+}

--- a/programs/token/GetAccountDataSize.go
+++ b/programs/token/GetAccountDataSize.go
@@ -1,0 +1,99 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+type GetAccountDataSize struct {
+	// [0] = [WRITE] mint
+	// ··········· The mint.
+	Mint *ag_solanago.AccountMeta `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *GetAccountDataSize) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	if len(accounts) != 1 {
+		return fmt.Errorf("expected 1 account, got %v", len(accounts))
+	}
+	inst.Mint = accounts[0]
+	return nil
+}
+
+func (inst GetAccountDataSize) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Mint)
+	return
+}
+
+func (inst GetAccountDataSize) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (inst *GetAccountDataSize) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+func NewGetAccountDataSizeInstructionBuilder() *GetAccountDataSize {
+	return &GetAccountDataSize{}
+}
+
+func (inst *GetAccountDataSize) SetMint(mint ag_solanago.PublicKey) *GetAccountDataSize {
+	inst.Mint = ag_solanago.Meta(mint).WRITE()
+	return inst
+}
+
+func (inst *GetAccountDataSize) GetMint() *ag_solanago.AccountMeta {
+	return inst.Mint
+}
+
+func (inst GetAccountDataSize) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_GetAccountDataSize),
+	}}
+}
+
+func (inst GetAccountDataSize) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *GetAccountDataSize) Validate() error {
+	if inst.Mint == nil {
+		return errors.New("accounts.Mint is not set")
+	}
+	return nil
+}
+
+func (inst *GetAccountDataSize) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("GetAccountDataSize")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("mint", inst.Mint))
+					})
+				})
+		})
+}

--- a/programs/token/InitializeImmutableOwner.go
+++ b/programs/token/InitializeImmutableOwner.go
@@ -1,0 +1,99 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"errors"
+	"fmt"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+type InitializeImmutableOwner struct {
+	// [0] = [WRITE] account
+	// ··········· The account to initialize.
+	Account *ag_solanago.AccountMeta `bin:"-" borsh_skip:"true"`
+}
+
+func (obj *InitializeImmutableOwner) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	if len(accounts) != 1 {
+		return fmt.Errorf("expected 1 account, got %v", len(accounts))
+	}
+	obj.Account = accounts[0]
+	return nil
+}
+
+func (slice InitializeImmutableOwner) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, slice.Account)
+	return
+}
+
+func (obj InitializeImmutableOwner) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	return nil
+}
+
+func (obj *InitializeImmutableOwner) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	return nil
+}
+
+func NewInitializeImmutableOwnerInstructionBuilder() *InitializeImmutableOwner {
+	return &InitializeImmutableOwner{}
+}
+
+func (inst *InitializeImmutableOwner) SetAccount(account ag_solanago.PublicKey) *InitializeImmutableOwner {
+	inst.Account = ag_solanago.Meta(account).WRITE()
+	return inst
+}
+
+func (inst *InitializeImmutableOwner) GetAccount() *ag_solanago.AccountMeta {
+	return inst.Account
+}
+
+func (inst InitializeImmutableOwner) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_InitializeImmutableOwner),
+	}}
+}
+
+func (inst InitializeImmutableOwner) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *InitializeImmutableOwner) Validate() error {
+	if inst.Account == nil {
+		return errors.New("accounts.Account is not set")
+	}
+	return nil
+}
+
+func (inst *InitializeImmutableOwner) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("InitializeImmutableOwner")).
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("account", inst.Account))
+					})
+				})
+		})
+}

--- a/programs/token/UiAmountToAmount.go
+++ b/programs/token/UiAmountToAmount.go
@@ -1,0 +1,159 @@
+// Copyright 2021 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"errors"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_format "github.com/gagliardetto/solana-go/text/format"
+)
+
+// Converts a `UiAmount` of tokens to a little-endian `u64` raw Amount,
+// using the given mint. In this version of the program, the mint can
+// only specify the number of decimals.
+type UiAmountToAmount struct {
+	// The `UiAmount` string to convert.
+	UiAmount *string
+
+	// [0] = [] mint
+	// ··········· The mint.
+	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+func (inst *UiAmountToAmount) SetAccounts(accounts []*ag_solanago.AccountMeta) error {
+	inst.Accounts = ag_solanago.AccountMetaSlice(accounts)
+	return nil
+}
+
+func (inst UiAmountToAmount) GetAccounts() (accounts []*ag_solanago.AccountMeta) {
+	accounts = append(accounts, inst.Accounts...)
+	return
+}
+
+// NewUiAmountToAmountInstructionBuilder creates a new `UiAmountToAmount` instruction builder.
+func NewUiAmountToAmountInstructionBuilder() *UiAmountToAmount {
+	nd := &UiAmountToAmount{
+		Accounts: make(ag_solanago.AccountMetaSlice, 1),
+	}
+	return nd
+}
+
+// SetUiAmount sets the "ui_amount" parameter.
+// The `UiAmount` string to convert.
+func (inst *UiAmountToAmount) SetUiAmount(uiAmount string) *UiAmountToAmount {
+	inst.UiAmount = &uiAmount
+	return inst
+}
+
+// SetMintAccount sets the "mint" account.
+// The mint.
+func (inst *UiAmountToAmount) SetMintAccount(mint ag_solanago.PublicKey) *UiAmountToAmount {
+	inst.Accounts[0] = ag_solanago.Meta(mint)
+	return inst
+}
+
+// GetMintAccount gets the "mint" account.
+// The mint.
+func (inst *UiAmountToAmount) GetMintAccount() *ag_solanago.AccountMeta {
+	return inst.Accounts[0]
+}
+
+func (inst UiAmountToAmount) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   inst,
+		TypeID: ag_binary.TypeIDFromUint8(Instruction_UiAmountToAmount),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (inst UiAmountToAmount) ValidateAndBuild() (*Instruction, error) {
+	if err := inst.Validate(); err != nil {
+		return nil, err
+	}
+	return inst.Build(), nil
+}
+
+func (inst *UiAmountToAmount) Validate() error {
+	// Check whether all (required) parameters are set:
+	{
+		if inst.UiAmount == nil {
+			return errors.New("UiAmount parameter is not set")
+		}
+	}
+
+	// Check whether all (required) accounts are set:
+	{
+		if inst.Accounts[0] == nil {
+			return errors.New("accounts.Mint is not set")
+		}
+	}
+	return nil
+}
+
+func (inst *UiAmountToAmount) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).
+		//
+		ParentFunc(func(programBranch ag_treeout.Branches) {
+			programBranch.Child(ag_format.Instruction("UiAmountToAmount")).
+				//
+				ParentFunc(func(instructionBranch ag_treeout.Branches) {
+
+					// Parameters of the instruction:
+					instructionBranch.Child("Params").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+						paramsBranch.Child(ag_format.Param("UiAmount", *inst.UiAmount))
+					})
+
+					// Accounts of the instruction:
+					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("mint", inst.Accounts[0]))
+					})
+				})
+		})
+}
+
+func (inst UiAmountToAmount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `UiAmount` param:
+	err = encoder.Encode(inst.UiAmount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (inst *UiAmountToAmount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `UiAmount`:
+	err = decoder.Decode(&inst.UiAmount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// NewUiAmountToAmountInstruction declares a new UiAmountToAmount instruction with the provided parameters and accounts.
+func NewUiAmountToAmountInstruction(
+	// Parameters:
+	uiAmount string,
+	// Accounts:
+	mint ag_solanago.PublicKey,
+) *UiAmountToAmount {
+	return NewUiAmountToAmountInstructionBuilder().
+		SetUiAmount(uiAmount).
+		SetMintAccount(mint)
+}

--- a/programs/token/instructions.go
+++ b/programs/token/instructions.go
@@ -23,9 +23,10 @@ import (
 
 	ag_spew "github.com/davecgh/go-spew/spew"
 	ag_binary "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+
 	ag_solanago "github.com/gagliardetto/solana-go"
 	ag_text "github.com/gagliardetto/solana-go/text"
-	ag_treeout "github.com/gagliardetto/treeout"
 )
 
 // Maximum number of multisignature signers (max N)
@@ -173,6 +174,23 @@ const (
 
 	// Like InitializeMint, but does not require the Rent sysvar to be provided.
 	Instruction_InitializeMint2
+
+	// Gets the required size of an account for the given mint as a
+	// little-endian `u64`.
+	Instruction_GetAccountDataSize
+
+	// Initialize the Immutable Owner extension for the given token account
+	Instruction_InitializeImmutableOwner
+
+	// Convert an Amount of tokens to a `UiAmount` string, using the given
+	// mint. In this version of the program, the mint can only specify the
+	// number of decimals.
+	Instruction_AmountToUiAmount
+
+	// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount,
+	// using the given mint. In this version of the program, the mint can
+	// only specify the number of decimals.
+	Instruction_UiAmountToAmount
 )
 
 // InstructionIDToName returns the name of the instruction given its ID.
@@ -220,6 +238,14 @@ func InstructionIDToName(id uint8) string {
 		return "InitializeMultisig2"
 	case Instruction_InitializeMint2:
 		return "InitializeMint2"
+	case Instruction_GetAccountDataSize:
+		return "GetAccountDataSize"
+	case Instruction_InitializeImmutableOwner:
+		return "InitializeImmutableOwner"
+	case Instruction_AmountToUiAmount:
+		return "AmountToUiAmount"
+	case Instruction_UiAmountToAmount:
+		return "UiAmountToAmount"
 	default:
 		return ""
 	}
@@ -302,6 +328,18 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 		},
 		{
 			"InitializeMint2", (*InitializeMint2)(nil),
+		},
+		{
+			"GetAccountDataSize", (*GetAccountDataSize)(nil),
+		},
+		{
+			"InitializeImmutableOwner", (*InitializeImmutableOwner)(nil),
+		},
+		{
+			"AmountToUiAmount", (*AmountToUiAmount)(nil),
+		},
+		{
+			"UiAmountToAmount", (*UiAmountToAmount)(nil),
 		},
 	},
 )

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2744,7 +2744,7 @@ func TestClient_GetTokenAccountBalance(t *testing.T) {
 }
 
 func TestClient_GetTokenAccountsByDelegate(t *testing.T) {
-	responseBody := `{"context":{"slot":1114},"value":[{"account":{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}]}`
+	responseBody := `{"context":{"slot":1114},"value":[{"account":{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4,"space":0},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}]}`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
 	defer closer()
 	client := New(server.URL)
@@ -2800,7 +2800,7 @@ func TestClient_GetTokenAccountsByDelegate(t *testing.T) {
 }
 
 func TestClient_GetTokenAccountsByOwner(t *testing.T) {
-	responseBody := `{"context":{"slot":1114},"value":[{"account":{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":null,"delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}]}`
+	responseBody := `{"context":{"slot":1114},"value":[{"account":{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","decimals":1,"uiAmount":0.1,"uiAmountString":"0.1"},"delegate":null,"delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"}}},"executable":false,"lamports":1726080,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":4,"space":0},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}]}`
 	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
 	defer closer()
 	client := New(server.URL)

--- a/rpc/getBlock.go
+++ b/rpc/getBlock.go
@@ -163,6 +163,10 @@ type GetBlockResult struct {
 
 	// The number of blocks beneath this block.
 	BlockHeight *uint64 `json:"blockHeight"`
+
+	// The number of reward partitions.
+	// Present for the first block in the epoch otherwise Nil.
+	NumRewardPartitions *uint64 `json:"numRewardPartitions"`
 }
 
 func (cl *Client) GetParsedBlockWithOpts(
@@ -230,6 +234,10 @@ type GetParsedBlockResult struct {
 
 	// The number of blocks beneath this block.
 	BlockHeight *uint64 `json:"blockHeight"`
+
+	// The number of reward partitions.
+	// Present for the first block in the epoch otherwise Nil.
+	NumRewardPartitions *uint64 `json:"numRewardPartitions"`
 }
 
 type ParsedTransactionWithMeta struct {

--- a/rpc/getParsedTransaction.go
+++ b/rpc/getParsedTransaction.go
@@ -131,7 +131,7 @@ func (obj GetParsedTransactionResult) MarshalWithEncoder(encoder *bin.Encoder) (
 	return nil
 }
 
-func (obj GetParsedTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+func (obj *GetParsedTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
 	// Deserialize `Slot`:
 	obj.Slot, err = decoder.ReadUint64(bin.LE)
 	if err != nil {

--- a/rpc/getParsedTransaction.go
+++ b/rpc/getParsedTransaction.go
@@ -22,6 +22,7 @@ type GetParsedTransactionResult struct {
 	BlockTime   *solana.UnixTimeSeconds
 	Transaction *ParsedTransaction
 	Meta        *ParsedTransactionMeta
+	Version     TransactionVersion `json:"version"`
 }
 
 func (cl *Client) GetParsedTransaction(

--- a/rpc/getTransaction.go
+++ b/rpc/getTransaction.go
@@ -231,6 +231,16 @@ func (obj GetTransactionResult) MarshalWithEncoder(encoder *bin.Encoder) (err er
 			}
 		}
 	}
+	{
+		buf, err := json.Marshal(obj.Version)
+		if err != nil {
+			return err
+		}
+		err = encoder.WriteBytes(buf, true)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -281,6 +291,16 @@ func (obj *GetTransactionResult) UnmarshalWithDecoder(decoder *bin.Decoder) (err
 			if err != nil {
 				return err
 			}
+		}
+	}
+	{
+		buf, err := decoder.ReadByteSlice()
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(buf, &obj.Version)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -322,6 +322,9 @@ type Account struct {
 
 	// The epoch at which this account will next owe rent
 	RentEpoch *big.Int `json:"rentEpoch"`
+
+	// The amount of storage space required to store the token account
+	Space uint64 `json:"space"`
 }
 
 type DataBytesOrJSON struct {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -376,6 +376,9 @@ func (wrap *DataBytesOrJSON) UnmarshalJSON(data []byte) error {
 // GetBinary returns the decoded bytes if the encoding is
 // "base58", "base64", or "base64+zstd".
 func (dt *DataBytesOrJSON) GetBinary() []byte {
+	if dt == nil {
+		return nil
+	}
 	return dt.asDecodedBinary.Content
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -153,6 +153,8 @@ type TokenBalance struct {
 
 	// Pubkey of token balance's owner.
 	Owner *solana.PublicKey `json:"owner,omitempty"`
+	// Pubkey of token program.
+	ProgramId *solana.PublicKey `json:"programId,omitempty"`
 
 	// Pubkey of the token's mint.
 	Mint          solana.PublicKey `json:"mint"`

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -234,7 +234,24 @@ type InnerInstruction struct {
 	Index uint16 `json:"index"`
 
 	// Ordered list of inner program instructions that were invoked during a single transaction instruction.
-	Instructions []solana.CompiledInstruction `json:"instructions"`
+	Instructions []CompiledInstruction `json:"instructions"`
+}
+
+type CompiledInstruction struct {
+	// Index into the message.accountKeys array indicating the program account that executes this instruction.
+	// NOTE: it is actually a uint8, but using a uint16 because uint8 is treated as a byte everywhere,
+	// and that can be an issue.
+	ProgramIDIndex uint16 `json:"programIdIndex"`
+
+	// List of ordered indices into the message.accountKeys array indicating which accounts to pass to the program.
+	// NOTE: it is actually a []uint8, but using a uint16 because []uint8 is treated as a []byte everywhere,
+	// and that can be an issue.
+	Accounts []uint16 `json:"accounts"`
+
+	// The program input data encoded in a base-58 string.
+	Data solana.Base58 `json:"data"`
+
+	StackHeight uint16 `json:"stackHeight"`
 }
 
 // Ok  interface{} `json:"Ok"`  // <null> Transaction was successful

--- a/rpc/ws/accountSubscribe.go
+++ b/rpc/ws/accountSubscribe.go
@@ -23,11 +23,9 @@ import (
 
 type AccountResult struct {
 	Context struct {
-		Slot uint64
+		Slot uint64 `json:"slot"`
 	} `json:"context"`
-	Value struct {
-		rpc.Account
-	} `json:"value"`
+	Value *rpc.Account `json:"value"`
 }
 
 // AccountSubscribe subscribes to an account to receive notifications

--- a/rpc/ws/accountSubscribe.go
+++ b/rpc/ws/accountSubscribe.go
@@ -15,6 +15,8 @@
 package ws
 
 import (
+	"context"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
@@ -83,8 +85,10 @@ type AccountSubscription struct {
 	sub *Subscription
 }
 
-func (sw *AccountSubscription) Recv() (*AccountResult, error) {
+func (sw *AccountSubscription) Recv(ctx context.Context) (*AccountResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/blockSubscribe.go
+++ b/rpc/ws/blockSubscribe.go
@@ -15,6 +15,7 @@
 package ws
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
@@ -148,8 +149,10 @@ type BlockSubscription struct {
 	sub *Subscription
 }
 
-func (sw *BlockSubscription) Recv() (*BlockResult, error) {
+func (sw *BlockSubscription) Recv(ctx context.Context) (*BlockResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/client_test.go
+++ b/rpc/ws/client_test.go
@@ -51,8 +51,8 @@ func Test_AccountSubscribe(t *testing.T) {
 		return
 	}
 	text.NewEncoder(os.Stdout).Encode(data, nil)
-	fmt.Println("OpenOrders: ", data.Value.Account.Owner)
-	fmt.Println("data: ", data.Value.Account.Data)
+	fmt.Println("OpenOrders: ", data.Value.Owner)
+	fmt.Println("data: ", data.Value.Data)
 	return
 }
 
@@ -107,8 +107,8 @@ func Test_AccountSubscribeWithHttpHeader(t *testing.T) {
 		t.Errorf("encoding error: %v", err)
 	}
 
-	t.Log("OpenOrders: ", data.Value.Account.Owner)
-	t.Log("data: ", data.Value.Account.Data)
+	t.Log("OpenOrders: ", data.Value.Owner)
+	t.Log("data: ", data.Value.Data)
 }
 
 func Test_ProgramSubscribe(t *testing.T) {

--- a/rpc/ws/client_test.go
+++ b/rpc/ws/client_test.go
@@ -45,7 +45,7 @@ func Test_AccountSubscribe(t *testing.T) {
 	sub, err := c.AccountSubscribe(accountID, "")
 	require.NoError(t, err)
 
-	data, err := sub.Recv()
+	data, err := sub.Recv(context.Background())
 	if err != nil {
 		fmt.Println("receive an error: ", err)
 		return
@@ -95,7 +95,7 @@ func Test_AccountSubscribeWithHttpHeader(t *testing.T) {
 		sub.Unsubscribe()
 	}(sub)
 
-	data, err := sub.Recv()
+	data, err := sub.Recv(context.Background())
 	if err != nil {
 		t.Errorf("Received an error: %v", err)
 	}
@@ -127,7 +127,7 @@ func Test_ProgramSubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	for {
-		data, err := sub.Recv()
+		data, err := sub.Recv(context.Background())
 		if err != nil {
 			fmt.Println("receive an error: ", err)
 			return
@@ -148,7 +148,7 @@ func Test_SlotSubscribe(t *testing.T) {
 	sub, err := c.SlotSubscribe()
 	require.NoError(t, err)
 
-	data, err := sub.Recv()
+	data, err := sub.Recv(context.Background())
 	if err != nil {
 		fmt.Println("receive an error: ", err)
 		return

--- a/rpc/ws/examples/accountSubscribe/accountSubscribe.go
+++ b/rpc/ws/examples/accountSubscribe/accountSubscribe.go
@@ -42,7 +42,7 @@ func main() {
 		defer sub.Unsubscribe()
 
 		for {
-			got, err := sub.Recv()
+			got, err := sub.Recv(context.Background())
 			if err != nil {
 				panic(err)
 			}
@@ -62,7 +62,7 @@ func main() {
 		defer sub.Unsubscribe()
 
 		for {
-			got, err := sub.Recv()
+			got, err := sub.Recv(context.Background())
 			if err != nil {
 				panic(err)
 			}

--- a/rpc/ws/examples/logsSubscribe/logsSubscribe.go
+++ b/rpc/ws/examples/logsSubscribe/logsSubscribe.go
@@ -24,6 +24,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
 	if err != nil {
 		panic(err)
@@ -43,7 +44,7 @@ func main() {
 		defer sub.Unsubscribe()
 
 		for {
-			got, err := sub.Recv()
+			got, err := sub.Recv(ctx)
 			if err != nil {
 				panic(err)
 			}
@@ -62,7 +63,7 @@ func main() {
 		defer sub.Unsubscribe()
 
 		for {
-			got, err := sub.Recv()
+			got, err := sub.Recv(ctx)
 			if err != nil {
 				panic(err)
 			}

--- a/rpc/ws/examples/programSubscribe/programSubscribe.go
+++ b/rpc/ws/examples/programSubscribe/programSubscribe.go
@@ -24,6 +24,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
 	if err != nil {
 		panic(err)
@@ -43,7 +44,7 @@ func main() {
 	defer sub.Unsubscribe()
 
 	for {
-		got, err := sub.Recv()
+		got, err := sub.Recv(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/ws/examples/rootSubscribe/rootSubscribe.go
+++ b/rpc/ws/examples/rootSubscribe/rootSubscribe.go
@@ -23,6 +23,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	client, err := ws.Connect(context.Background(), rpc.TestNet_WS)
 	if err != nil {
 		panic(err)
@@ -35,7 +36,7 @@ func main() {
 	}
 
 	for {
-		got, err := sub.Recv()
+		got, err := sub.Recv(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/ws/examples/signatureSubscribe/signatureSubscribe.go
+++ b/rpc/ws/examples/signatureSubscribe/signatureSubscribe.go
@@ -24,6 +24,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	client, err := ws.Connect(context.Background(), rpc.TestNet_WS)
 	if err != nil {
 		panic(err)
@@ -42,7 +43,7 @@ func main() {
 	defer sub.Unsubscribe()
 
 	for {
-		got, err := sub.Recv()
+		got, err := sub.Recv(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/ws/examples/slotSubscribe/slotSubscribe.go
+++ b/rpc/ws/examples/slotSubscribe/slotSubscribe.go
@@ -23,6 +23,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	client, err := ws.Connect(context.Background(), rpc.TestNet_WS)
 	if err != nil {
 		panic(err)
@@ -36,7 +37,7 @@ func main() {
 	defer sub.Unsubscribe()
 
 	for {
-		got, err := sub.Recv()
+		got, err := sub.Recv(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/ws/examples/voteSubscribe/voteSubscribe.go
+++ b/rpc/ws/examples/voteSubscribe/voteSubscribe.go
@@ -23,6 +23,7 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	client, err := ws.Connect(context.Background(), rpc.MainNetBeta_WS)
 	if err != nil {
 		panic(err)
@@ -38,7 +39,7 @@ func main() {
 	defer sub.Unsubscribe()
 
 	for {
-		got, err := sub.Recv()
+		got, err := sub.Recv(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/rpc/ws/logsSubscribe.go
+++ b/rpc/ws/logsSubscribe.go
@@ -15,6 +15,8 @@
 package ws
 
 import (
+	"context"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
@@ -107,8 +109,10 @@ type LogSubscription struct {
 	sub *Subscription
 }
 
-func (sw *LogSubscription) Recv() (*LogResult, error) {
+func (sw *LogSubscription) Recv(ctx context.Context) (*LogResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/parsedBlockSubscribe.go
+++ b/rpc/ws/parsedBlockSubscribe.go
@@ -15,6 +15,8 @@
 package ws
 
 import (
+	"context"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
@@ -92,8 +94,10 @@ type ParsedBlockSubscription struct {
 	sub *Subscription
 }
 
-func (sw *ParsedBlockSubscription) Recv() (*ParsedBlockResult, error) {
+func (sw *ParsedBlockSubscription) Recv(ctx context.Context) (*ParsedBlockResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d := <-sw.sub.stream:
 		return d.(*ParsedBlockResult), nil
 	case err := <-sw.sub.err:

--- a/rpc/ws/programSubscribe.go
+++ b/rpc/ws/programSubscribe.go
@@ -15,6 +15,8 @@
 package ws
 
 import (
+	"context"
+
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 )
@@ -86,8 +88,10 @@ type ProgramSubscription struct {
 	sub *Subscription
 }
 
-func (sw *ProgramSubscription) Recv() (*ProgramResult, error) {
+func (sw *ProgramSubscription) Recv(ctx context.Context) (*ProgramResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/rootSubscribe.go
+++ b/rpc/ws/rootSubscribe.go
@@ -14,6 +14,8 @@
 
 package ws
 
+import "context"
+
 type RootResult uint64
 
 // SignatureSubscribe subscribes to receive notification
@@ -42,8 +44,10 @@ type RootSubscription struct {
 	sub *Subscription
 }
 
-func (sw *RootSubscription) Recv() (*RootResult, error) {
+func (sw *RootSubscription) Recv(ctx context.Context) (*RootResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/signatureSubscribe.go
+++ b/rpc/ws/signatureSubscribe.go
@@ -15,6 +15,7 @@
 package ws
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -67,8 +68,10 @@ type SignatureSubscription struct {
 	sub *Subscription
 }
 
-func (sw *SignatureSubscription) Recv() (*SignatureResult, error) {
+func (sw *SignatureSubscription) Recv(ctx context.Context) (*SignatureResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/slotSubscribe.go
+++ b/rpc/ws/slotSubscribe.go
@@ -14,6 +14,8 @@
 
 package ws
 
+import "context"
+
 type SlotResult struct {
 	Parent uint64 `json:"parent"`
 	Root   uint64 `json:"root"`
@@ -45,8 +47,10 @@ type SlotSubscription struct {
 	sub *Subscription
 }
 
-func (sw *SlotSubscription) Recv() (*SlotResult, error) {
+func (sw *SlotSubscription) Recv(ctx context.Context) (*SlotResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/slotsUpdatesSubscribe.go
+++ b/rpc/ws/slotsUpdatesSubscribe.go
@@ -14,7 +14,11 @@
 
 package ws
 
-import "github.com/gagliardetto/solana-go"
+import (
+	"context"
+
+	"github.com/gagliardetto/solana-go"
+)
 
 type SlotsUpdatesResult struct {
 	// The parent slot.
@@ -77,8 +81,10 @@ type SlotsUpdatesSubscription struct {
 	sub *Subscription
 }
 
-func (sw *SlotsUpdatesSubscription) Recv() (*SlotsUpdatesResult, error) {
+func (sw *SlotsUpdatesSubscription) Recv(ctx context.Context) (*SlotsUpdatesResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/rpc/ws/subscription.go
+++ b/rpc/ws/subscription.go
@@ -17,6 +17,8 @@
 
 package ws
 
+import "context"
+
 type Subscription struct {
 	req               *request
 	subID             uint64
@@ -47,8 +49,10 @@ func newSubscription(
 	}
 }
 
-func (s *Subscription) Recv() (interface{}, error) {
+func (s *Subscription) Recv(ctx context.Context) (interface{}, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d := <-s.stream:
 		return d, nil
 	case err := <-s.err:

--- a/rpc/ws/voteSubscribe.go
+++ b/rpc/ws/voteSubscribe.go
@@ -15,6 +15,8 @@
 package ws
 
 import (
+	"context"
+
 	"github.com/gagliardetto/solana-go"
 )
 
@@ -59,8 +61,10 @@ type VoteSubscription struct {
 	sub *Subscription
 }
 
-func (sw *VoteSubscription) Recv() (*VoteResult, error) {
+func (sw *VoteSubscription) Recv(ctx context.Context) (*VoteResult, error) {
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case d, ok := <-sw.sub.stream:
 		if !ok {
 			return nil, ErrSubscriptionClosed

--- a/transaction.go
+++ b/transaction.go
@@ -802,3 +802,16 @@ func getStaticAccountIndex(tx *Transaction, key PublicKey) (int, bool) {
 	}
 	return -1, false
 }
+
+func (tx *Transaction) IsVote() bool {
+	// is vote if any of the instructions are of the vote program
+	for _, inst := range tx.Message.Instructions {
+		progKey, err := tx.ResolveProgramIDIndex(inst.ProgramIDIndex)
+		if err == nil {
+			if progKey.Equals(VoteProgramID) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `programs/stake-pool` package, primarily adding a new instruction and making various improvements and adjustments to existing instructions. The most important changes include the addition of the `DecreaseValidatorStakeWithReserve` instruction, updates to the `IncreaseAdditionalValidatorStake` instruction, and reordering of constants in `instructions.go`.

### New Instruction Addition:
* [`programs/stake-pool/DecreaseValidatorStakeWithReserve.go`](diffhunk://#diff-9671851000affb42d69b331f15762b9fa9cd2eae01a019038d5dcce1e246c27bR1-R301): Added a new instruction `DecreaseValidatorStakeWithReserve` with methods for setting and getting accounts and parameters, validating, building, encoding, and decoding the instruction.

### Updates to Existing Instructions:
* [`programs/stake-pool/IncreaseAdditionalValidatorStake.go`](diffhunk://#diff-02a007ecbdc6f104e68fe4c6949ba107a547bffc80a1ca936948790461400255R19): Added methods `GetAccounts` and `SetAccounts` to manage accounts, simplified `MarshalWithEncoder` and `UnmarshalWithDecoder` methods, and added `FindEphemeralAccount` method to find a program address. [[1]](diffhunk://#diff-02a007ecbdc6f104e68fe4c6949ba107a547bffc80a1ca936948790461400255R19) [[2]](diffhunk://#diff-02a007ecbdc6f104e68fe4c6949ba107a547bffc80a1ca936948790461400255R94-R102) [[3]](diffhunk://#diff-02a007ecbdc6f104e68fe4c6949ba107a547bffc80a1ca936948790461400255L269-R283) [[4]](diffhunk://#diff-02a007ecbdc6f104e68fe4c6949ba107a547bffc80a1ca936948790461400255R300-R313)

### Reordering of Constants:
* [`programs/stake-pool/instructions.go`](diffhunk://#diff-7a5442e363257c045a0bd39d971c31cdb61c40caca74ce480295ecf526324781L60-R68): Reordered constants to include the new `DecreaseValidatorStakeWithReserve` and adjusted the positions of other constants for better organization.